### PR TITLE
Fixing null handilg in ValueAndTimestampSerializer

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializer.java
@@ -57,6 +57,10 @@ public class ValueAndTimestampSerializer<V> implements Serializer<ValueAndTimest
             return null;
         }
         final byte[] rawValue = valueSerializer.serialize(topic, data);
+        if (rawValue == null) {
+            return null;
+        }
+        
         final byte[] rawTimestamp = timestampSerializer.serialize(topic, timestamp);
         return ByteBuffer
             .allocate(rawTimestamp.length + rawValue.length)


### PR DESCRIPTION
Since `ValueAndTimestampSerializer` wraps an unknown `Serializer`, the output of that `Serializer` can be `null`. In which case the line
```java
.allocate(rawTimestamp.length + rawValue.length)
```
will throw a `NullPointerException`.

This pull request returns `null` instead.

Not sure where to put tests for it, any suggestions would be appreciated.
